### PR TITLE
modified:   README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
     cd ~
     git clone http://github.com/zjrosen1/vim.git ~/.vim
     ln -s ~/.vim/vimrc ~/.vimrc
-    ln -s ~/.vim/gvimrc ~/.gvimrc
     cd ~/.vim
     git submodule update --init 
 


### PR DESCRIPTION
Removed the line: ln -s ~/.vim/gvimrc ~/.gvimrc
No gvimrc text file exists in master to symlink to.
